### PR TITLE
Fix torch.load failure in generate_indices.py for PyTorch 2.6+

### DIFF
--- a/rq/generate_indices.py
+++ b/rq/generate_indices.py
@@ -48,7 +48,12 @@ output_file = f"{dataset}.index.json"
 output_file = os.path.join(output_dir,output_file)
 device = torch.device("cuda:0")
 
-ckpt = torch.load(ckpt_path, map_location=torch.device('cpu'))
+ckpt = torch.load(
+    ckpt_path,
+    map_location=torch.device('cpu'),
+    weights_only=False
+)
+
 args = ckpt["args"]
 state_dict = ckpt["state_dict"]
 


### PR DESCRIPTION
**Summary**

Fixes a crash in generate_indices.py when running on PyTorch 2.6+, where torch.load defaults to weights_only=True.
Explicitly setting weights_only=False restores compatibility with existing MiniOneRec checkpoints that contain Python objects.

**Changes**

Updated checkpoint loading in generate_indices.py:

ckpt = torch.load(
    ckpt_path,
    map_location=torch.device('cpu'),
    weights_only=False
)


Ensures full checkpoint (weights + args + metadata) can be unpickled normally.

**Motivation**

PyTorch 2.6 changed the default of torch.load to weights_only=True, which breaks loading MiniOneRec RQVAE checkpoints since they store more than just raw model weights.
This update makes generate_indices.py work correctly on modern PyTorch versions without requiring users to downgrade.

**Tested**

Successfully ran:
```
python rq/generate_indices.py
```

on PyTorch 2.6.0, confirming the checkpoint loads and index generation proceeds normally.