### PR TITLE
Fix rq/rqkmeans_faiss.py Residual Quantizer Encoding Unpacking Issue for Non-8-bit-Aligned Codebook Sizes

### DIFF
--- a/rq/rqkmeans_faiss.py
+++ b/rq/rqkmeans_faiss.py
@@ -263,7 +263,7 @@ def main():
     print("shape:", data.shape)
 
     rq = train_faiss_rq(data, args.num_levels, args.codebook_size)
-    codes_raw = encode_with_rq(rq, data, verbose=True)
+    codes_raw = encode_with_rq(rq, data, args.codebook_size, verbose=True)
 
     analyze_codes(codes_raw, "Before balancing:")
 


### PR DESCRIPTION
## Problem Description

When using FAISS's Residual Quantizer, we observed unexpected behavior:
- With `codebook_size=256` with num_level=3, `rq.compute_codes()` returns shape `(N, 3)` as expected
- With `codebook_size=512` with num_level=3, the returned shape becomes `(N, 4)` with the last dimension having max value of only 7

This occurs because FAISS uses bit packing for memory efficiency:
- `codebook_size=256`: Each index requires 8 bits, 3 levels fit exactly in 3 bytes
- `codebook_size=512`: Each index requires 9 bits, 3 levels need 27 bits total, packed into 4 bytes

The raw output from `compute_codes()` contains compact byte storage, not the actual integer indices users expect.

## Solution

1. **Add unpacking function**: Implement `unpack_rq_codes()` to convert FAISS's packed byte format into actual integer indices
2. **Encode function enhancement**: Upgrade `encode_with_rq()` to automatically detect and handle bit-packed scenarios
3. **Backward compatibility**: Maintain existing behavior for 8-bit-aligned cases (256, 65536, etc.)

## Key Changes
add unpack_rq_codes function,see below

## Impact
- Fixes encoding issues for non-8-bit-aligned codebooks in rqkmeans_faiss.py

## Test
- I have tested codebook_size=512 with num_level=3 returns correctly shaped `(N, 3)` integer array and index value range is correct: [0,511]. And codebook_size=1024 with num_level=3 returns correctly shaped `(N, 3)` integer array and index value range is correct: [0,1023].
- I have tested with 10000 real embedding data, results shows that same pairs of encoded neighbours of codebook_size=1024 are also neighbours of codebook_size=512, proving the correctness of encoding result.
<img width="445" height="151" alt="image" src="https://github.com/user-attachments/assets/8ca8f98e-e8bd-4ce6-86e1-3bdfc9ef0522" />

