### PR TITLE
Fix: invalid tokens

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -174,6 +174,8 @@ def main(
             pad_token_id = model.config.pad_token_id,
             eos_token_id = model.config.eos_token_id,
             max_new_tokens = max_new_tokens,
+            top_k=None,
+            top_p=None,
             **kwargs
         )
         

--- a/minionerec_trainer.py
+++ b/minionerec_trainer.py
@@ -488,6 +488,8 @@ class ReReTrainer(Trainer):
                     eos_token_id=processing_class.eos_token_id,
                     top_k=None,
                     top_p=None,
+                    temperature=self.temperature,
+                    do_sample=True,
                     # temperature=self.temperature,
                     # do_sample=True, # if self.temperature > 1.0 else False,
                 )

--- a/minionerec_trainer.py
+++ b/minionerec_trainer.py
@@ -486,6 +486,8 @@ class ReReTrainer(Trainer):
                     num_return_sequences=self.num_generations,
                     pad_token_id=processing_class.pad_token_id,
                     eos_token_id=processing_class.eos_token_id,
+                    top_k=None,
+                    top_p=None,
                     # temperature=self.temperature,
                     # do_sample=True, # if self.temperature > 1.0 else False,
                 )


### PR DESCRIPTION
## Related Issues:
+ #56 
+ #49 
+ #52 
+ #50 

## Reason:

### [Qwen/Qwen2.5-7B-Instruct](https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/blob/main/generation_config.json#L11-L12)
+ https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/blob/main/generation_config.json#L11-L12
```json
{
"bos_token_id": 151643,
"pad_token_id": 151643,
"do_sample": true,
"eos_token_id": [
151645,
151643
],
"repetition_penalty": 1.05,
"temperature": 0.7,
"top_p": 0.8,
"top_k": 20,
"transformers_version": "4.37.0"
}
```

### [Qwen/Qwen3-1.7B-Base](https://huggingface.co/Qwen/Qwen3-1.7B-Base/blob/main/generation_config.json)
```json
{
"bos_token_id": 151643,
"do_sample": false,
"eos_token_id": 151643,
"max_new_tokens": 2048,
"transformers_version": "4.37.0"
}
```

### [kkknight/MiniOneRec](https://huggingface.co/kkknight/MiniOneRec/blob/main/Industrial_ckpt/generation_config.json)

```json
{
"_from_model_config": true,
"bos_token_id": 151643,
"eos_token_id": 151645,
"transformers_version": "4.55.4"
}
```

`Instruct` model contain `top_k` and `top_p`, which lead to `TopKLogitsWarper`...
https://github.com/huggingface/transformers/blob/5a67f0a7aca8c18de6235e80e47fd00a9ecf9d58/src/transformers/generation/logits_process.py#L581-L586

may filter the 50 valid tokens(after constrained beam search=`50`) down to even `only 2` valid tokens(valid means logits is not `-inf`). So the other 50-2=48 breams are selected in all the tokens with logits == `-inf` with `top-k` beam selection.

<img width="958" height="236" alt="ce54caa3698d472a5a4b10ac7d9fdb6b" src="https://github.com/user-attachments/assets/15fc6dbe-8485-483d-94e0-e9661fc145b7" />



#### Since so many related issues, I highly recommend to fix this to support `instrct` model to align with the model in paper.



> Qwen2.5-1.5B-instrct sft result before fixing the bug
<img width="1170" height="230" alt="f1ea6eaa66027a742dbc7fbfdda96904" src="https://github.com/user-attachments/assets/ae7e00a4-b996-4133-960e-98ae7f37e06e" />

> Qwen2.5-1.5B-instrct stf result after fixing the bug
<img width="1176" height="276" alt="a34b4a1b5897d59fd053cbbc2aac525b" src="https://github.com/user-attachments/assets/37c82947-323b-4896-bf44-d7bf8ea7ab10" />

