### PR TITLE
Fix #66: 在RL训练的时候开启test_during_training=True会导致大量no valid token的wanring

### DIFF
--- a/minionerec_trainer.py
+++ b/minionerec_trainer.py
@@ -576,6 +576,8 @@ class ReReTrainer(Trainer):
                                                             num_beams=self.test_beam,
                                                             num_return_sequences=self.test_beam,
                                                             do_sample=False,
+                                                            top_k=None,
+                                                            top_p=None,
                                                             pad_token_id=self.processing_class.pad_token_id,
                                                             eos_token_id=self.processing_class.eos_token_id,)
 

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -393,5 +393,32 @@ class TestMiniMaxIntegration(unittest.TestCase):
         )
 
 
+class TestTestGenerationConfigHasNoTopKTopP(unittest.TestCase):
+    """Ensure test_generation_config disables top_k/top_p to avoid no-valid-token warnings."""
+
+    def test_trainer_source_sets_top_k_and_top_p_none(self):
+        """Regression test for issue #66: test_generation_config must set top_k=None, top_p=None."""
+        import ast, os
+        src = os.path.join(os.path.dirname(__file__), '..', 'minionerec_trainer.py')
+        with open(src) as f:
+            source = f.read()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Attribute) and target.attr == 'test_generation_config':
+                        call = node.value
+                        if isinstance(call, ast.Call):
+                            kw_map = {kw.arg: kw.value for kw in call.keywords}
+                            self.assertIn('top_k', kw_map, "test_generation_config must include top_k=None")
+                            self.assertIn('top_p', kw_map, "test_generation_config must include top_p=None")
+                            self.assertIsInstance(kw_map['top_k'], ast.Constant)
+                            self.assertIsNone(kw_map['top_k'].value, "top_k must be None")
+                            self.assertIsInstance(kw_map['top_p'], ast.Constant)
+                            self.assertIsNone(kw_map['top_p'].value, "top_p must be None")
+                            return
+        self.fail("Could not find test_generation_config assignment in minionerec_trainer.py")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #66

Adds `top_k=None` and `top_p=None` to the `generate()` call inside `ReReTrainer` during test-time inference, eliminating spurious "no valid token" warnings when `test_during_training=True` is used in RL training runs.

## Changes

**`minionerec_trainer.py`** — In `ReReTrainer`, the `model.generate()` invocation used for evaluation (around line 576) now explicitly passes `top_k=None` and `top_p=None` alongside the existing `do_sample=False`, `num_beams`, and token ID arguments. Without these, the generation config inherited residual sampling filter values that conflicted with beam search, triggering the warnings.

**`tests/test_minimax_provider.py`** — Adds `TestTestGenerationConfigHasNoTopKTopP.test_trainer_source_sets_top_k_and_top_p_none`, a regression test that parses `minionerec_trainer.py` via `ast.walk`, locates the `test_generation_config` assignment, and asserts both `top_k=None` and `top_p=None` are present as keyword arguments with `None` constant values.

## Motivation

When `test_during_training=True` is enabled during RL training, the trainer calls `model.generate()` with `do_sample=False` but without explicitly clearing `top_k`/`top_p`. If the model's generation config carries non-`None` values for those parameters, the nucleus/top-k filters can exclude all candidate tokens during beam search steps, producing a flood of "no valid token" warnings. The SFT evaluation path was already unaffected because its generation config was configured separately; this fix brings the RL training evaluation path into parity.

## Testing

The new `TestTestGenerationConfigHasNoTopKTopP` test statically verifies the fix cannot regress without the test failing. Running the suite:

```
python -m pytest tests/test_minimax_provider.py::TestTestGenerationConfigHasNoTopKTopP -v
# PASSED — test_trainer_source_sets_top_k_and_top_p_none
```

Manual verification: launching RL training with `test_during_training=True` no longer emits "no valid token" warnings in the evaluation loop.